### PR TITLE
Enable multiple libraries from Google Maps API

### DIFF
--- a/src/usePlacesWidget.js
+++ b/src/usePlacesWidget.js
@@ -8,6 +8,7 @@ export default function usePlacesWidget(props) {
     ref,
     onPlaceSelected,
     apiKey,
+    libraries = ["places"],
     inputAutocompleteValue = "new-password",
     options: {
       types = ["(cities)"],
@@ -29,7 +30,7 @@ export default function usePlacesWidget(props) {
   const autocompleteRef = useRef(null);
   const observerHack = useRef(null);
   const languageQueryParam = language ? `&language=${language}` : "";
-  const googleMapsScriptUrl = `${googleMapsScriptBaseUrl}?libraries=places&key=${apiKey}${languageQueryParam}`;
+  const googleMapsScriptUrl = `${googleMapsScriptBaseUrl}?libraries=${libraries.toString()}&key=${apiKey}${languageQueryParam}`;
 
   const handleLoadScript = useCallback(
     () => loadGoogleMapScript(googleMapsScriptBaseUrl, googleMapsScriptUrl),


### PR DESCRIPTION
Enable multiple libraries from Google Maps API.

Default: `places`.

The following change allows developers to include other Google Maps API libraries that they may need.

`libraries` will be an array of Libraries represented as strings. Eventually the array is returned as a string with `libraries.toString()`.

E.g)
```
libraries = ["places", "geometry"]

libraries.toString()
// outputs: places,geometry
```

In many use cases with Google Maps a developer may need to use more than one Library and the following PR covers these cases.